### PR TITLE
feat: feed order flag

### DIFF
--- a/cmd/goread/goread.go
+++ b/cmd/goread/goread.go
@@ -30,6 +30,7 @@ type options struct {
 	dumpColors      bool
 	testColors      bool
 	resetCache      bool
+	order           string
 }
 
 var (
@@ -44,6 +45,10 @@ var (
 			if err := Run(); err != nil {
 				fmt.Fprintf(os.Stderr, "There has been an error executing the commands: '%s'", err)
 				os.Exit(1)
+			}
+			if opts.order != "chronological" && opts.order != "reverse-chronological" && opts.order != "reverse" {
+				opts.order = "chronological"
+				fmt.Println("Invalid order value. Use either 'chronological' or 'reverse-chronological' or 'reverse'.")
 			}
 		},
 	}
@@ -61,6 +66,7 @@ func init() {
 	rootCmd.Flags().IntVarP(&opts.cacheDuration, "cache_duration", "", 0, "The duration of the cache in hours")
 	rootCmd.Flags().StringVarP(&opts.loadOPMLFrom, "load_opml", "i", "", "Import the feeds from an OPML file")
 	rootCmd.Flags().StringVarP(&opts.exportOPMLTo, "export_opml", "e", "", "Export the feeds to an OPML file")
+        rootCmd.Flags().StringVarP(&opts.order, "order", "o", "chronological", "Set feed order to 'chronological' or 'reverse-chronological' or 'reverse'")
 }
 
 // SetVersion sets the version of the program
@@ -146,7 +152,7 @@ func Run() error {
 	}
 
 	// Initialize the backend
-	backend, err := backend.New(opts.urlsPath, opts.cacheDir, opts.resetCache)
+	backend, err := backend.New(opts.urlsPath, opts.cacheDir, opts.resetCache, opts.order != "reverse-chronological" && opts.order != "reverse")
 	if err != nil {
 		log.Println("Failed to initialize backend: ", err)
 		return err

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"errors"
 	"log"
+        "sort"
 
 	"github.com/TypicalAM/goread/internal/backend/cache"
 	"github.com/TypicalAM/goread/internal/backend/rss"
@@ -17,10 +18,11 @@ type Backend struct {
 	Rss        *rss.Rss
 	Cache      *cache.Cache
 	ReadStatus *cache.ReadStatus
+	order      bool
 }
 
 // New creates a new backend and its components.
-func New(urlPath, cacheDir string, resetCache bool) (*Backend, error) {
+func New(urlPath, cacheDir string, resetCache bool, order bool) (*Backend, error) {
 	log.Println("Creating new backend")
 	store, err := cache.New(cacheDir)
 	if err != nil {
@@ -51,7 +53,7 @@ func New(urlPath, cacheDir string, resetCache bool) (*Backend, error) {
 		log.Println("Rss load failed: ", err)
 	}
 
-	return &Backend{rss, store, readStatus}, nil
+	return &Backend{rss, store, readStatus, order}, nil
 }
 
 // FetchCategories gets the categories.
@@ -172,6 +174,10 @@ func (b Backend) Close() error {
 func (b Backend) articlesToSuccessMsg(items cache.SortableArticles) FetchArticleSuccessMsg {
 	result := make([]list.Item, len(items))
 	contents := make([]string, len(items))
+
+	if !b.order {
+		sort.Sort(sort.Reverse(cache.SortableArticles(items)))
+	}
 
 	for i, item := range items {
 		if b.ReadStatus.IsRead(item) {


### PR DESCRIPTION
This feature adds a way to list the feed in chronological (default) or reverse chronological order using the order/o flag.