### PR TITLE
docs: add homebrew installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ go install github.com/TypicalAM/goread@latest
 
 ### Installing with `homebrew`
 
-Add repository
+If you use [Homebrew](https://brew.sh/), you can install [goread](https://formulae.brew.sh/formula/goread) via:
 
 ```
-brew tap TypicalAM/goread && brew install goread
+$ brew install goread
 ```
 
 ### Installing from AUR (yay)
@@ -137,4 +137,3 @@ The demo was made using [vhs](https://github.com/charmbracelet/vhs/), which is a
 ### Fonts & logo
 
 The font in use for the logo is sen-regular designed by "Philatype" and licensed under Open Font License. The icon was designed by throwaway icons.
-


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/140502

```
$ brew install goread
==> Fetching goread
==> Downloading https://ghcr.io/v2/homebrew/core/goread/manifests/1.6.2
#################################################################################################### 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/goread/blobs/sha256:1b87335f5c2a6ca5323ced3f2746f3799281e8
#################################################################################################### 100.0%
==> Reinstalling goread
==> Pouring goread--1.6.2.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/goread/1.6.2: 5 files, 21.7MB
```