### PR TITLE
Return error if failed to load Rss from URLs file

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -51,6 +51,7 @@ func New(urlPath, cacheDir string, resetCache bool) (*Backend, error) {
 
 	if err = rss.Load(); err != nil {
 		log.Println("Rss load failed: ", err)
+		return nil, fmt.Errorf("backend.New: %w", err)
 	}
 
 	return &Backend{rss, store, readStatus}, nil


### PR DESCRIPTION
In the current `main`, if the `urls.yml` file can't be parsed, execution continues while only logging an error to the log (and not directly warning the user of anything). Then, when the app fully loads up, the 'default' urls.yml configuration is written to the `urls.yml` file, overwriting any configuration the user had done without warning.

This fixes that problem by returning an error whenever the program can't load the specified urls.yml file. This then will tell the user exactly what went wrong instead of silently failing and overwriting their configuration.