### PR TITLE
Option to perform tests in offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ If you have an idea or something doesn't work feel free to create an issue. If i
 - Include output of `goread --version`
 - Include logs which are usually located at `/tmp/goread.log` on linux and `%TMP%\goread.log` on Windows
 
+When running tests (for example when packaging) you can disable online tests by setting the env var `TEST_OFFLINE_ONLY` to a truthy value (for example "YES").
+
 ## 💁 Credit where credit is due
 
 ### Libraries

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1,10 +1,31 @@
 package backend
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/TypicalAM/goread/internal/backend/rss"
 )
+
+const TEST_OFFLINE_ENV = "TEST_OFFLINE_ONLY"
+
+// testOffline checks if the tests should be in offline mode
+func testOffline() bool {
+	offline, ok := os.LookupEnv(TEST_OFFLINE_ENV)
+	if !ok {
+		return false
+	}
+
+	truthy := []string{"1", "YES", "Y", "TRUE", "ON"}
+	for _, val := range truthy {
+		if strings.ToUpper(offline) == val {
+			return true
+		}
+	}
+
+	return false
+}
 
 // getBackend creates a fake backend
 func getBackend() (*Backend, error) {
@@ -90,6 +111,12 @@ func TestBackendGetFeeds(t *testing.T) {
 
 // TestBackendGetArticles if we get an error getting items from a feed doesn't work
 func TestBackendGetArticles(t *testing.T) {
+	// This test should only run online
+	if testOffline() {
+		t.Skip()
+		return
+	}
+
 	// Create a backend with a valid file
 	b, err := getBackend()
 	if err != nil {

--- a/internal/backend/cache/cache_test.go
+++ b/internal/backend/cache/cache_test.go
@@ -1,9 +1,30 @@
 package cache
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
+
+const TEST_OFFLINE_ENV = "TEST_OFFLINE_ONLY"
+
+// testOffline checks if the tests should be in offline mode
+func testOffline() bool {
+	offline, ok := os.LookupEnv(TEST_OFFLINE_ENV)
+	if !ok {
+		return false
+	}
+
+	truthy := []string{"1", "YES", "Y", "TRUE", "ON"}
+	for _, val := range truthy {
+		if strings.ToUpper(offline) == val {
+			return true
+		}
+	}
+
+	return false
+}
 
 // getCache returns a new cache with the fake data
 func getCache() (*Cache, error) {
@@ -53,6 +74,12 @@ func TestCacheLoadCorrectly(t *testing.T) {
 
 // TestCacheGetArticles if we get an error when there's a cache miss but the cache doesn't change
 func TestCacheGetArticles(t *testing.T) {
+	// This test should only run online
+	if testOffline() {
+		t.Skip()
+		return
+	}
+
 	// Create the cache object with a valid file
 	cache, err := getCache()
 	if err != nil {
@@ -86,6 +113,12 @@ func TestCacheGetArticles(t *testing.T) {
 
 // TestCacheGetArticleExpired if we get an error then the store doesn't delete expired cache when getting data
 func TestCacheGetArticleExpired(t *testing.T) {
+	// This test should only run online
+	if testOffline() {
+		t.Skip()
+		return
+	}
+
 	// Create the cache object with a valid file
 	cache, err := getCache()
 	if err != nil {


### PR DESCRIPTION
Added `TEST_OFFLINE_ONLY` an environment variable used to run tests only in offline mode, skipping fetching data from remote servers.