### PR TITLE
Whitelisting and blacklisting keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ categories:
       - name: BBC
         desc: News from the BBC
         url: http://feeds.bbci.co.uk/news/rss.xml
+        blacklist_words:
+          - example
   - name: Tech
     desc: Tech news
     subscriptions:
@@ -78,6 +80,8 @@ categories:
       - name: Chris Titus Tech (virtualization)
         desc: Chris Titus Tech on virtualization
         url: https://christitus.com/categories/virtualization/index.xml
+        whitelist_words:
+          - qemu
 ```
 
 You can edit this file to change the app's contents in an automated manner (remember that you can also edit entries in the TUI!).

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -90,12 +90,12 @@ func (b Backend) FetchFeeds(catname string) tea.Cmd {
 // FetchArticles gets the articles from a feed.
 func (b Backend) FetchArticles(feedname string, refresh bool) tea.Cmd {
 	return func() tea.Msg {
-		url, err := b.Rss.GetFeedURL(feedname)
+		feed, err := b.Rss.GetFeed(feedname)
 		if err != nil {
 			return FetchErrorMsg{err, "Error while trying to get the article url"}
 		}
 
-		items, err := b.Cache.GetArticles(url, refresh)
+		items, err := b.Cache.GetArticles(*feed, refresh)
 		if err != nil {
 			return FetchErrorMsg{err, "Error while fetching the article"}
 		}
@@ -107,7 +107,7 @@ func (b Backend) FetchArticles(feedname string, refresh bool) tea.Cmd {
 // FetchAllArticles gets all the articles from all the feeds.
 func (b Backend) FetchAllArticles(_ string, refresh bool) tea.Cmd {
 	return func() tea.Msg {
-		return b.articlesToSuccessMsg(b.Cache.GetArticlesBulk(b.Rss.GetAllURLs(), refresh))
+		return b.articlesToSuccessMsg(b.Cache.GetArticlesBulk(b.Rss.GetAllFeeds(), refresh))
 	}
 }
 
@@ -193,18 +193,18 @@ func (b Backend) indexToItem(feedName string, index int) (*gofeed.Item, error) {
 
 	switch feedName {
 	case rss.AllFeedsName:
-		articles = b.Cache.GetArticlesBulk(b.Rss.GetAllURLs(), false)
+		articles = b.Cache.GetArticlesBulk(b.Rss.GetAllFeeds(), false)
 
 	case rss.DownloadedFeedsName:
 		articles = b.Cache.GetDownloaded()
 
 	default:
-		url, err := b.Rss.GetFeedURL(feedName)
+		feed, err := b.Rss.GetFeed(feedName)
 		if err != nil {
 			return nil, errors.New("getting the article url")
 		}
 
-		articles, err = b.Cache.GetArticles(url, false)
+		articles, err = b.Cache.GetArticles(*feed, false)
 		if err != nil {
 			return nil, errors.New("fetching the article")
 		}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -95,7 +95,7 @@ func (b Backend) FetchArticles(feedname string, refresh bool) tea.Cmd {
 			return FetchErrorMsg{err, "Error while trying to get the article url"}
 		}
 
-		items, err := b.Cache.GetArticles(*feed, refresh)
+		items, err := b.Cache.GetArticles(feed, refresh)
 		if err != nil {
 			return FetchErrorMsg{err, "Error while fetching the article"}
 		}
@@ -204,7 +204,7 @@ func (b Backend) indexToItem(feedName string, index int) (*gofeed.Item, error) {
 			return nil, errors.New("getting the article url")
 		}
 
-		articles, err = b.Cache.GetArticles(*feed, false)
+		articles, err = b.Cache.GetArticles(feed, false)
 		if err != nil {
 			return nil, errors.New("fetching the article")
 		}

--- a/internal/backend/cache/cache.go
+++ b/internal/backend/cache/cache.go
@@ -123,7 +123,7 @@ func (c *Cache) Save() error {
 }
 
 // GetArticles returns an article list using the cache if possible
-func (c *Cache) GetArticles(feed rss.Feed, ignoreCache bool) (SortableArticles, error) {
+func (c *Cache) GetArticles(feed *rss.Feed, ignoreCache bool) (SortableArticles, error) {
 	log.Println("Getting articles for", feed.URL, " from cache: ", !ignoreCache)
 
 	// Delete entry if expired
@@ -176,8 +176,8 @@ func (c *Cache) GetArticles(feed rss.Feed, ignoreCache bool) (SortableArticles, 
 func (c *Cache) GetArticlesBulk(feeds []*rss.Feed, ignoreCache bool) SortableArticles {
 	var result SortableArticles
 
-	for _, feed := range feeds {
-		if items, err := c.GetArticles(*feed, ignoreCache); err == nil {
+	for i, feed := range feeds {
+		if items, err := c.GetArticles(feeds[i], ignoreCache); err == nil {
 			result = append(result, items...)
 		} else {
 			// NOTE: Let's say you have 50 feeds and 5 fail, we don't want to keep trying failed feeds

--- a/internal/backend/cache/cache.go
+++ b/internal/backend/cache/cache.go
@@ -282,7 +282,10 @@ func getDefaultDir() (string, error) {
 // includesKeywords checks if an article contains any specified keyword from a slice
 func includesKeywords(feed *gofeed.Item, keywords []string) bool {
 	for _, keyword := range keywords {
-		if strings.Contains(feed.Title, keyword) || strings.Contains(feed.Description, keyword) || strings.Contains(feed.Content, keyword) {
+		lowerKeyword := strings.ToLower(keyword)
+		if strings.Contains(strings.ToLower(feed.Title), lowerKeyword) ||
+			strings.Contains(strings.ToLower(feed.Description), lowerKeyword) ||
+			strings.Contains(strings.ToLower(feed.Content), lowerKeyword) {
 			return true
 		}
 	}

--- a/internal/backend/cache/cache_test.go
+++ b/internal/backend/cache/cache_test.go
@@ -113,6 +113,94 @@ func TestCacheGetArticles(t *testing.T) {
 	}
 }
 
+// TestCacheRespectWhitelist if we get an error then the whitelist isn't being respected
+func TestCacheRespectWhitelist(t *testing.T) {
+	// This test should only run online
+	if testOffline() {
+		t.Skip()
+		return
+	}
+
+	// Create the cache object with a valid file
+	cache, err := getCache()
+	if err != nil {
+		t.Fatalf("couldn't load the cache %v", err)
+	}
+
+	// Get articles with no whitelist
+	exampleFeed := rss.Feed{URL: "https://primordialsoup.info/feed"}
+	articles, err := cache.GetArticles(exampleFeed, false)
+	if err != nil {
+		t.Fatalf("couldn't get article: %v", err)
+	}
+
+	// Refetch articles
+	exampleFeed.WhitelistWords = []string{"Samuel"}
+	whitelistedArticles, err := cache.GetArticles(exampleFeed, true)
+	if len(whitelistedArticles) == len(articles) {
+		t.Errorf("whitelisting failed to filter articles, same number of articles as initial set")
+	}
+
+	if len(whitelistedArticles) == 0 {
+		t.Errorf("whitelisting failed to filter articles, no articles with the words %v detected", exampleFeed.WhitelistWords)
+	}
+
+	// Refetch articles with lowercase filtering
+	exampleFeed.WhitelistWords = []string{"samuel"}
+	whitelistedLowerArticles, err := cache.GetArticles(exampleFeed, true)
+	if len(whitelistedLowerArticles) == len(articles) {
+		t.Errorf("whitelisting failed to filter case-sensitive articles, same number of articles as initial set")
+	}
+
+	if len(whitelistedLowerArticles) == 0 {
+		t.Errorf("whitelisting failed to filter case-sensitive articles, no articles with the words %v detected", exampleFeed.WhitelistWords)
+	}
+}
+
+// TestCacheRespectBlacklist if we get an error then the blacklist isn't being respected
+func TestCacheRespectBlacklist(t *testing.T) {
+	// This test should only run online
+	if testOffline() {
+		t.Skip()
+		return
+	}
+
+	// Create the cache object with a valid file
+	cache, err := getCache()
+	if err != nil {
+		t.Fatalf("couldn't load the cache %v", err)
+	}
+
+	// Get articles with no blacklist
+	exampleFeed := rss.Feed{URL: "https://primordialsoup.info/feed"}
+	articles, err := cache.GetArticles(exampleFeed, false)
+	if err != nil {
+		t.Fatalf("couldn't get article: %v", err)
+	}
+
+	// Refetch articles
+	exampleFeed.BlacklistWords = []string{"Samuel"}
+	blacklistedArticles, err := cache.GetArticles(exampleFeed, true)
+	if len(blacklistedArticles) == len(articles) {
+		t.Errorf("blacklisting failed to filter articles, same number of articles as initial set")
+	}
+
+	if len(blacklistedArticles) == 0 {
+		t.Errorf("blacklisting failed to filter articles, no articles without the words %v detected", exampleFeed.BlacklistWords)
+	}
+
+	// Refetch articles with lowercase filtering
+	exampleFeed.BlacklistWords = []string{"samuel"}
+	blacklistedLowerArticles, err := cache.GetArticles(exampleFeed, true)
+	if len(blacklistedLowerArticles) == len(articles) {
+		t.Errorf("blacklisting failed to filter case-sensitive articles, same number of articles as initial set")
+	}
+
+	if len(blacklistedLowerArticles) == 0 {
+		t.Errorf("blacklisting failed to filter case-sensitive articles, no articles without the words %v detected", exampleFeed.BlacklistWords)
+	}
+}
+
 // TestCacheGetArticleExpired if we get an error then the store doesn't delete expired cache when getting data
 func TestCacheGetArticleExpired(t *testing.T) {
 	// This test should only run online

--- a/internal/backend/cache/cache_test.go
+++ b/internal/backend/cache/cache_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/TypicalAM/goread/internal/backend/rss"
 )
 
 const TestOfflineDev = "TEST_OFFLINE_ONLY"
@@ -87,7 +89,7 @@ func TestCacheGetArticles(t *testing.T) {
 	}
 
 	// Check if the cache hit works
-	_, err = cache.GetArticles("https://primordialsoup.info/feed", false)
+	_, err = cache.GetArticles(rss.Feed{URL: "https://primordialsoup.info/feed"}, false)
 	if err != nil {
 		t.Fatalf("couldn't get article: %v", err)
 	}
@@ -97,7 +99,7 @@ func TestCacheGetArticles(t *testing.T) {
 	}
 
 	// Check if the cache miss retrieves the item and puts it inside the cache
-	_, err = cache.GetArticles("https://christitus.com/categories/virtualization/index.xml", false)
+	_, err = cache.GetArticles(rss.Feed{URL: "https://christitus.com/categories/virtualization/index.xml"}, false)
 	if err != nil {
 		t.Fatalf("couldn't get article: %v", err)
 	}
@@ -135,7 +137,7 @@ func TestCacheGetArticleExpired(t *testing.T) {
 	oldItem.Expire = time.Now().Add(-2 * DefaultCacheDuration)
 	cache.Content["https://primordialsoup.info/feed"] = oldItem
 
-	_, err = cache.GetArticles("https://primordialsoup.info/feed", false)
+	_, err = cache.GetArticles(rss.Feed{URL: "https://primordialsoup.info/feed"}, false)
 	if err != nil {
 		t.Fatalf("couldn't get article: %v", err)
 	}

--- a/internal/backend/rss/rss.go
+++ b/internal/backend/rss/rss.go
@@ -115,14 +115,6 @@ func (rss *Rss) Load() error {
 		return fmt.Errorf("rss.Load: %w", err)
 	}
 
-	for _, cat := range rss.Categories {
-		for _, feed := range cat.Subscriptions {
-			if len(feed.WhitelistWords) != 0 && len(feed.BlacklistWords) != 0 {
-				return fmt.Errorf("rss.Load: feed %s has both a whitelist and a blacklist", feed.Name)
-			}
-		}
-	}
-
 	log.Printf("Rss loaded with %d categories\n", len(rss.Categories))
 	return nil
 }

--- a/internal/backend/rss/rss.go
+++ b/internal/backend/rss/rss.go
@@ -172,9 +172,9 @@ func (rss Rss) GetAllFeeds() []*Feed {
 	var feeds []*Feed
 
 	for _, cat := range rss.Categories {
-		for _, feed := range cat.Subscriptions {
+		for i, feed := range cat.Subscriptions {
 			if feed.URL != AllFeedsName {
-				feeds = append(feeds, &feed)
+				feeds = append(feeds, &cat.Subscriptions[i])
 			}
 		}
 	}

--- a/internal/backend/rss/rss_test.go
+++ b/internal/backend/rss/rss_test.go
@@ -87,16 +87,16 @@ func TestRssGetFeeds(t *testing.T) {
 // TestRssGetFeedURL if we get an error then the rss feed url is not retrieved correctly
 func TestRssGetFeedURL(t *testing.T) {
 	myRss := getRss(t)
-	url, err := myRss.GetFeedURL(myRss.Categories[0].Subscriptions[0].Name)
+	feed, err := myRss.GetFeed(myRss.Categories[0].Subscriptions[0].Name)
 	if err != nil {
 		t.Errorf("failed to get feed url, %s", err)
 	}
 
-	if url != "https://primordialsoup.info/feed" {
-		t.Errorf("incorrect url, expected https://primordialsoup.info/feed, got %s", url)
+	if feed.URL != "https://primordialsoup.info/feed" {
+		t.Errorf("incorrect url, expected https://primordialsoup.info/feed, got %s", feed.URL)
 	}
 
-	if _, err = myRss.GetFeedURL("Non-existent"); err == nil || err != ErrNotFound {
+	if _, err = myRss.GetFeed("Non-existent"); err == nil || err != ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %s", err)
 	}
 }
@@ -104,13 +104,13 @@ func TestRssGetFeedURL(t *testing.T) {
 // TestRssGetAllURLs if we get an error then all the urls are not retrieved correctly
 func TestRssGetAllURLs(t *testing.T) {
 	myRss := getRss(t)
-	urls := myRss.GetAllURLs()
+	urls := myRss.GetAllFeeds()
 
 	if len(urls) != 3 {
 		t.Errorf("incorrect number of urls, expected 2, got %d", len(urls))
 	}
 
-	if urls[0] != "https://primordialsoup.info/feed" {
+	if urls[0].URL != "https://primordialsoup.info/feed" {
 		t.Errorf("incorrect url, expected https://primordialsoup.info/feed, got %s", urls[0])
 	}
 }


### PR DESCRIPTION
Added:
- You can now add `blacklist_words` and `whitelist_words` to your `urls.yml` to filter out articles that you dont like, an example is also included in the README
- This functionality is only feed-based and only definable by `urls.yml` for the sake of maintaining configuration simplicity

```yaml
categories:
    - name: News
      desc: News from around the world
      subscriptions:
        - name: BBC
          desc: News from the BBC
          url: http://feeds.bbci.co.uk/news/rss.xml
          blacklist_words:
            - example
    - name: Tech
      desc: Tech news
      subscriptions:
        - name: Wired
          desc: News from the wired team
          url: https://www.wired.com/feed/rss
        - name: Chris Titus Tech (virtualization)
          desc: Chris Titus Tech on virtualization
          url: https://christitus.com/categories/virtualization/index.xml
          whitelist_words:
            - qemu
```