### PR TITLE
Pager support

### DIFF
--- a/internal/backend/message.go
+++ b/internal/backend/message.go
@@ -127,6 +127,16 @@ func SetEnableKeybind(enable bool) tea.Cmd {
 	return func() tea.Msg { return SetEnableKeybindMsg(enable) }
 }
 
+// ShowErrorMsg is an error message "thrown" by a tab
+type ShowErrorMsg struct {
+	Msg string
+}
+
+// ShowError is called from a tab to tell the browser to show an error msg
+func ShowError(msg string) tea.Cmd {
+	return func() tea.Msg { return ShowErrorMsg{Msg: msg} }
+}
+
 // StartQuittingMsg prompts the browser to start quitting (and perform a last browser redraw).
 type StartQuittingMsg struct{}
 

--- a/internal/ui/browser/browser.go
+++ b/internal/ui/browser/browser.go
@@ -215,6 +215,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case backend.MakeChoiceMsg:
 		return m.showPopup(lollypops.NewChoice(m.style.colors, msg.Question, msg.Default))
 
+	case backend.ShowErrorMsg:
+		m.keymap.SetEnabled(true)
+		m.popup = nil
+		return m.showPopup(lollypops.NewError(m.style.colors, msg.Msg))
+
 	case lollypops.ChoiceResultMsg, lollypops.ErrorResultMsg, closeHelpMsg:
 		m.keymap.SetEnabled(true)
 		m.popup = nil

--- a/internal/ui/tab/feed/keymap.go
+++ b/internal/ui/tab/feed/keymap.go
@@ -7,6 +7,7 @@ type Keymap struct {
 	Open            key.Binding
 	ToggleFocus     key.Binding
 	RefreshArticles key.Binding
+	OpenInPager     key.Binding
 	SaveArticle     key.Binding
 	DeleteFromSaved key.Binding
 	CycleSelection  key.Binding
@@ -26,6 +27,10 @@ var DefaultKeymap = Keymap{
 	RefreshArticles: key.NewBinding(
 		key.WithKeys("r", "ctrl+r"),
 		key.WithHelp("r/ctrl+r", "Refresh"),
+	),
+	OpenInPager: key.NewBinding(
+		key.WithKeys("p", "ctrl+p"),
+		key.WithHelp("p/ctrl+p", "Open in pager"),
 	),
 	SaveArticle: key.NewBinding(
 		key.WithKeys("s", "ctrl+s"),


### PR DESCRIPTION
Added
- Support for the `PAGER` environment variable which now can be used to view files in the system pager, like `less` using the `p` shortcut by default

![pager](https://github.com/user-attachments/assets/4141d745-b9fd-46f0-bee2-6357fe0842da)