### PR TITLE
Custom keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ the `--dump_colors` flag. The colorscheme file is usually at `~/.config/goread/c
 You can use the `--get_colors` flag to generate a colorscheme from pywal. For that you have to supply it with the
 pywal `colors.json` file which is usually located at `~/.cache/wal/colors.json`. To generate the `colors.json` file you can run `wal -stni ~/wallpapers/example.png`.
 
+### 📝 The config file
+
+You can configure custom keybindings for goread in `goread.yml` in the same directory as the urls file, for an example see: #59
+
 ## ✨ Contributing
 
 If you have an idea or something doesn't work feel free to create an issue. If it is a bug remember to:

--- a/cmd/goread/goread.go
+++ b/cmd/goread/goread.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/TypicalAM/goread/internal/backend"
 	"github.com/TypicalAM/goread/internal/backend/cache"
+	"github.com/TypicalAM/goread/internal/config"
 	"github.com/TypicalAM/goread/internal/theme"
 	"github.com/TypicalAM/goread/internal/ui/browser"
 )
@@ -23,6 +24,7 @@ type options struct {
 	cacheDir        string
 	colorschemePath string
 	urlsPath        string
+	configPath      string
 	getColors       string
 	loadOPMLFrom    string
 	exportOPMLTo    string
@@ -61,6 +63,7 @@ func init() {
 	rootCmd.Flags().
 		StringVarP(&opts.colorschemePath, "colorscheme_path", "c", "", "The path to the colorscheme file")
 	rootCmd.Flags().StringVarP(&opts.urlsPath, "urls_path", "u", "", "The path to the urls file")
+	rootCmd.Flags().StringVarP(&opts.configPath, "config_path", "s", "", "The path to the configuration file")
 	rootCmd.Flags().BoolVarP(&opts.testColors, "test_colors", "", false, "Test the colorscheme")
 	rootCmd.Flags().
 		BoolVarP(&opts.dumpColors, "dump_colors", "", false, "Dump the colors to the colorscheme file")
@@ -161,6 +164,18 @@ func Run() error {
 	if opts.cacheDuration > 0 {
 		log.Println("Setting cache duration to ", opts.cacheDuration)
 		cache.DefaultCacheDuration = time.Hour * time.Duration(opts.cacheDuration)
+	}
+
+	// Get the config
+	cfg, err := config.New(opts.configPath)
+	if err != nil {
+		log.Println("Failed to initialize config: ", err)
+		return err
+	}
+
+	if err := cfg.Load(); err != nil {
+		log.Println("Failed to load config: ", err)
+		return err
 	}
 
 	// Initialize the backend

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/TypicalAM/goread/internal/ui/browser"
+	"github.com/TypicalAM/goread/internal/ui/simplelist"
+	"github.com/TypicalAM/goread/internal/ui/tab/category"
+	"github.com/TypicalAM/goread/internal/ui/tab/feed"
+	"github.com/TypicalAM/goread/internal/ui/tab/overview"
+	"github.com/charmbracelet/bubbles/key"
+	"gopkg.in/yaml.v3"
+)
+
+var Default = Config{}
+
+var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+
+type Config struct {
+	Keymap map[string]KeymapConfig `yaml:"keymap"`
+
+	filePath string
+}
+
+type KeymapConfig map[string]KeyList
+
+type KeyList []string
+
+// New will create a new config structure
+func New(path string) (*Config, error) {
+	log.Println("Creating new settings")
+	if path == "" {
+		defaultPath, err := getDefaultPath()
+		if err != nil {
+			return nil, fmt.Errorf("cfg.New: %w", err)
+		}
+
+		// Set the path
+		path = defaultPath
+	}
+
+	cfg := Default
+	cfg.filePath = path
+	return &cfg, nil
+}
+
+// Load will try to load the config structure from a file
+func (cfg *Config) Load() error {
+	log.Println("Loading config from", cfg.filePath)
+	data, err := os.ReadFile(cfg.filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("cfg.Load: %w", err)
+	}
+
+	if err = yaml.Unmarshal(data, cfg); err != nil {
+		return fmt.Errorf("cfg.Load: %w", err)
+	}
+
+	// Apply the config
+	allowedKeymaps := []string{"browser", "overview", "category", "feed", "list"}
+	for keyCategory, keymap := range cfg.Keymap {
+		if !slices.Contains(allowedKeymaps, keyCategory) {
+			return fmt.Errorf("cfg.Load: unrecognized keymap: %s", keyCategory)
+		}
+
+		var keymapType reflect.Type
+		var keymapValue reflect.Value
+		switch keyCategory {
+		case "browser":
+			keymapType = reflect.TypeOf(browser.DefaultKeymap)
+			keymapValue = reflect.ValueOf(&browser.DefaultKeymap)
+		case "overview":
+			keymapType = reflect.TypeOf(overview.DefaultKeymap)
+			keymapValue = reflect.ValueOf(&overview.DefaultKeymap)
+		case "category":
+			keymapType = reflect.TypeOf(category.DefaultKeymap)
+			keymapValue = reflect.ValueOf(&category.DefaultKeymap)
+		case "feed":
+			keymapType = reflect.TypeOf(feed.DefaultKeymap)
+			keymapValue = reflect.ValueOf(&feed.DefaultKeymap)
+		case "list":
+			keymapType = reflect.TypeOf(simplelist.DefaultKeymap)
+			keymapValue = reflect.ValueOf(&simplelist.DefaultKeymap)
+		}
+
+		fields := reflect.VisibleFields(keymapType)
+		snakeToOriginal := make(map[string]string, len(fields))
+		origHelpText := make(map[string]string, len(fields))
+		for _, field := range fields {
+			snakeToOriginal[toSnakeCase(field.Name)] = field.Name
+			origHelpText[field.Name] = keymapValue.
+				Elem().
+				FieldByName(field.Name).
+				MethodByName("Help").
+				Call([]reflect.Value{})[0].
+				FieldByName("Desc").
+				String()
+		}
+
+		for name, keys := range keymap {
+			if _, ok := snakeToOriginal[name]; !ok {
+				b := strings.Builder{}
+				for name := range snakeToOriginal {
+					b.WriteRune(' ')
+					b.WriteString(name)
+				}
+				return fmt.Errorf("cfg.Load: %s doesn't exist on %s, available options are:%s", name, keyCategory, b.String())
+			}
+
+			if len(keys) == 0 {
+				return fmt.Errorf("cfg.Load: option %s on category %s doesn't have any keys bound", name, keyCategory)
+			}
+
+			specialKeys := map[string]string{"up": "↑", "down": "↓", "left": "←", "right": "→"}
+			s := strings.Builder{}
+			for _, key := range keys {
+				if specialKey, ok := specialKeys[key]; ok {
+					s.WriteString(specialKey)
+				} else {
+					s.WriteString(key)
+				}
+				s.WriteRune('/')
+			}
+			helpKeyStr := s.String()[:s.Len()-1] // cut off the last '/'
+
+			origName := snakeToOriginal[name]
+			newBind := key.NewBinding(key.WithKeys(keys...), key.WithHelp(helpKeyStr, origHelpText[origName]))
+			keymapValue.Elem().FieldByName(origName).Set(reflect.ValueOf(newBind))
+		}
+	}
+	return nil
+}
+
+// getDefaultPath will return the default path for the config file
+func getDefaultPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("cfg.getDefaultPath: %w", err)
+	}
+
+	return filepath.Join(configDir, "goread", "goread.yml"), nil
+}
+
+// toSnakeCase transforms the pascalCase string to snake_case
+func toSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/TypicalAM/goread/internal/ui/browser"
+)
+
+func getCfg(t *testing.T) *Config {
+	myCfg, err := New("../test/data/goread.yml")
+	if err != nil {
+		t.Errorf("error creating config object: %v", err)
+	}
+
+	if err = myCfg.Load(); err != nil {
+		t.Errorf("error loading file: %v", err)
+	}
+
+	return myCfg
+}
+
+// TestConfigLoadNoFile if we get an error then the config file is not loaded correctly
+func TestConfigLoadNoFile(t *testing.T) {
+	myCfg, err := New("non-existent")
+	if err != nil {
+		t.Errorf("error creating config object: %v", err)
+	}
+
+	if err = myCfg.Load(); err != nil {
+		t.Errorf("no error returned when loading non-existent file")
+	}
+}
+
+// TestConfigLoadFile if we get an error then the config file is not loaded correctly
+func TestConfigLoadFile(t *testing.T) {
+	cfg := getCfg(t)
+	if len(cfg.Keymap) != 5 {
+		t.Errorf("incorrect number of keymap categories, expected 5, got %d", len(cfg.Keymap))
+	}
+
+	if _, ok := cfg.Keymap["category"]; !ok {
+		t.Error("incorrect map, expected category to exist")
+	}
+
+	keys := browser.DefaultKeymap.CloseTab.Keys()
+	if !slices.Contains(keys, "EXTRA") {
+		t.Errorf("incorrect keys loaded, expected 'EXTRA' in %v", keys)
+	}
+}
+
+// TestConfigLoadFile if we get an error then the config loader doesn't recognize non-existant categories
+func TestConfigLoadBadCategory(t *testing.T) {
+	myCfg, err := New("../test/data/goread_bad_category.yml")
+	if err != nil {
+		t.Fatalf("error creating config object: %v", err)
+	}
+
+	if err = myCfg.Load(); err == nil {
+		t.Fatalf("expected error when loading file with non-existent category, but got none")
+	}
+}
+
+// TestConfigLoadFile if we get an error then the config file allows for a bad attribute of category to be defined
+func TestConfigLoadBadBind(t *testing.T) {
+	myCfg, err := New("../test/data/goread_bad_bind.yml")
+	if err != nil {
+		t.Errorf("error creating config object: %v", err)
+	}
+
+	if err = myCfg.Load(); err == nil {
+		t.Error("expected error when loading file with invalid binds to the 'browser' category, but got none")
+	}
+}
+
+// TestConfigLoadFile if we get an error then the config file allows for bindings with no keys attached
+func TestConfigLoadNoKeys(t *testing.T) {
+	myCfg, err := New("../test/data/goread_no_keys.yml")
+	if err != nil {
+		t.Errorf("error creating config object: %v", err)
+	}
+
+	if err = myCfg.Load(); err == nil {
+		t.Error("expected error when loading file with bindings missing keys, but got none")
+	}
+}

--- a/internal/test/data/goread.yml
+++ b/internal/test/data/goread.yml
@@ -1,0 +1,76 @@
+keymap:
+  browser:
+    close_tab:
+      - c
+      - ctrl+w
+      - EXTRA
+    next_tab:
+      - tab
+    prev_tab:
+      - shift+tab
+    show_help:
+      - h
+      - ctrl+h
+    toggle_offline_mode:
+      - o
+      - ctrl+o
+  category:
+    delete_feed:
+      - d
+      - ctrl+d
+    edit_feed:
+      - e
+      - ctrl+e
+    new_feed:
+      - n
+      - ctrl+n
+  feed:
+    cycle_selection:
+      - g
+    delete_from_saved:
+      - d
+    mark_as_unread:
+      - u
+    open:
+      - enter
+    open_in_pager:
+      - p
+      - ctrl+p
+    refresh_articles:
+      - r
+      - ctrl+r
+    save_article:
+      - s
+      - ctrl+s
+    toggle_focus:
+      - left
+      - right
+      - h
+      - l
+  list:
+    down:
+      - down
+      - j
+    open:
+      - enter
+    page_down:
+      - shift+down
+      - J
+    page_up:
+      - shift+up
+      - K
+    quick_select:
+      - 0-9
+    up:
+      - up
+      - k
+  overview:
+    delete_category:
+      - d
+      - ctrl+d
+    edit_category:
+      - e
+      - ctrl+e
+    new_category:
+      - n
+      - ctrl+n

--- a/internal/test/data/goread_bad_bind.yml
+++ b/internal/test/data/goread_bad_bind.yml
@@ -1,0 +1,6 @@
+keymap:
+  browser:
+    close_tab_NONEXISTENT:
+      - c
+      - ctrl+w
+      - EXTRA

--- a/internal/test/data/goread_bad_category.yml
+++ b/internal/test/data/goread_bad_category.yml
@@ -1,0 +1,5 @@
+keymap:
+  shrimp:
+    fried:
+      - this
+      - rice

--- a/internal/test/data/goread_no_keys.yml
+++ b/internal/test/data/goread_no_keys.yml
@@ -1,0 +1,3 @@
+keymap:
+  browser:
+    close_tab:

--- a/internal/ui/browser/browser.go
+++ b/internal/ui/browser/browser.go
@@ -22,48 +22,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Keymap contains the key bindings for the browser
-type Keymap struct {
-	CloseTab          key.Binding
-	NextTab           key.Binding
-	PrevTab           key.Binding
-	ShowHelp          key.Binding
-	ToggleOfflineMode key.Binding
-}
-
-// DefaultKeymap contains the default key bindings for the browser
-var DefaultKeymap = Keymap{
-	CloseTab: key.NewBinding(
-		key.WithKeys("c", "ctrl+w"),
-		key.WithHelp("c", "Close tab"),
-	),
-	NextTab: key.NewBinding(
-		key.WithKeys("tab"),
-		key.WithHelp("Tab", "Next tab"),
-	),
-	PrevTab: key.NewBinding(
-		key.WithKeys("shift+tab"),
-		key.WithHelp("Shift+Tab", "Previous tab"),
-	),
-	ShowHelp: key.NewBinding(
-		key.WithKeys("h", "ctrl+h"),
-		key.WithHelp("h", "Help"),
-	),
-	ToggleOfflineMode: key.NewBinding(
-		key.WithKeys("o", "ctrl+o"),
-		key.WithHelp("o", "Offline mode"),
-	),
-}
-
-// SetEnabled allows to disable/enable shortcuts
-func (k *Keymap) SetEnabled(enabled bool) {
-	k.CloseTab.SetEnabled(enabled)
-	k.NextTab.SetEnabled(enabled)
-	k.PrevTab.SetEnabled(enabled)
-	k.ShowHelp.SetEnabled(enabled)
-	k.ToggleOfflineMode.SetEnabled(enabled)
-}
-
 // Model is used to store the state of the application
 type Model struct {
 	popup          popup.Window

--- a/internal/ui/browser/keymap.go
+++ b/internal/ui/browser/keymap.go
@@ -1,0 +1,45 @@
+package browser
+
+import "github.com/charmbracelet/bubbles/key"
+
+// Keymap contains the key bindings for the browser
+type Keymap struct {
+	CloseTab          key.Binding
+	NextTab           key.Binding
+	PrevTab           key.Binding
+	ShowHelp          key.Binding
+	ToggleOfflineMode key.Binding
+}
+
+// DefaultKeymap contains the default key bindings for the browser
+var DefaultKeymap = Keymap{
+	CloseTab: key.NewBinding(
+		key.WithKeys("c", "ctrl+w"),
+		key.WithHelp("c", "Close tab"),
+	),
+	NextTab: key.NewBinding(
+		key.WithKeys("tab"),
+		key.WithHelp("Tab", "Next tab"),
+	),
+	PrevTab: key.NewBinding(
+		key.WithKeys("shift+tab"),
+		key.WithHelp("Shift+Tab", "Previous tab"),
+	),
+	ShowHelp: key.NewBinding(
+		key.WithKeys("h", "ctrl+h"),
+		key.WithHelp("h", "Help"),
+	),
+	ToggleOfflineMode: key.NewBinding(
+		key.WithKeys("o", "ctrl+o"),
+		key.WithHelp("o", "Offline mode"),
+	),
+}
+
+// SetEnabled allows to disable/enable shortcuts
+func (k *Keymap) SetEnabled(enabled bool) {
+	k.CloseTab.SetEnabled(enabled)
+	k.NextTab.SetEnabled(enabled)
+	k.PrevTab.SetEnabled(enabled)
+	k.ShowHelp.SetEnabled(enabled)
+	k.ToggleOfflineMode.SetEnabled(enabled)
+}

--- a/internal/ui/simplelist/keymap.go
+++ b/internal/ui/simplelist/keymap.go
@@ -1,0 +1,41 @@
+package simplelist
+
+import "github.com/charmbracelet/bubbles/key"
+
+// Keymap is the Keymap for the list
+type Keymap struct {
+	Open        key.Binding
+	Up          key.Binding
+	Down        key.Binding
+	PageUp      key.Binding
+	PageDown    key.Binding
+	QuickSelect key.Binding
+}
+
+// DefaultKeymap is the default keymap for the list
+var DefaultKeymap = Keymap{
+	Open: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("Enter", "Open"),
+	),
+	Up: key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "Move up"),
+	),
+	Down: key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "Move down"),
+	),
+	PageUp: key.NewBinding(
+		key.WithKeys("shift+up", "K"),
+		key.WithHelp("shift+↑/K", "Page up"),
+	),
+	PageDown: key.NewBinding(
+		key.WithKeys("shift+down", "J"),
+		key.WithHelp("shift+↓/J", "Page down"),
+	),
+	QuickSelect: key.NewBinding(
+		key.WithKeys("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"),
+		key.WithHelp("0-9", "Quick select"),
+	),
+}

--- a/internal/ui/simplelist/list.go
+++ b/internal/ui/simplelist/list.go
@@ -11,34 +11,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Keymap is the Keymap for the list
-type Keymap struct {
-	Open        key.Binding
-	Up          key.Binding
-	Down        key.Binding
-	QuickSelect key.Binding
-}
-
-// DefaultKeymap is the default keymap for the list
-var DefaultKeymap = Keymap{
-	Open: key.NewBinding(
-		key.WithKeys("enter"),
-		key.WithHelp("Enter", "Open"),
-	),
-	Up: key.NewBinding(
-		key.WithKeys("up", "k"),
-		key.WithHelp("↑/k", "Move up"),
-	),
-	Down: key.NewBinding(
-		key.WithKeys("down", "j"),
-		key.WithHelp("↓/j", "Move down"),
-	),
-	QuickSelect: key.NewBinding(
-		key.WithKeys("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"),
-		key.WithHelp("0-9", "Quick select"),
-	),
-}
-
 // Item is an item in the list
 type Item struct {
 	title string
@@ -111,8 +83,8 @@ func (m Model) Init() tea.Cmd {
 // Update updates the model
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	if msg, ok := msg.(tea.KeyMsg); ok {
-		switch msg.String() {
-		case "up", "k":
+		switch {
+		case key.Matches(msg, m.Keymap.Up):
 			m.selected--
 			if m.selected < 0 {
 				m.selected = len(m.items) - 1
@@ -124,7 +96,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				m.page--
 			}
 
-		case "down", "j":
+		case key.Matches(msg, m.Keymap.Down):
 			m.selected++
 			if m.selected >= len(m.items) {
 				m.selected = 0
@@ -135,11 +107,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				m.page++
 			}
 
-		case "shift+up", "K":
+		case key.Matches(msg, m.Keymap.PageUp):
 			m.selected = 0
 			m.page = 0
 
-		case "shift+down", "J":
+		case key.Matches(msg, m.Keymap.PageDown):
 			m.selected = len(m.items) - 1
 			m.page = len(m.items) / m.itemsPerPage
 		}


### PR DESCRIPTION
Added
- Custom keymaps which are now available via `~/.config/goread/goread.yml`, this file will be the new `config` file for later use. Below is an example file with the default keymap presented, it is also available [here](https://github.com/TypicalAM/goread/blob/main/internal/test/data/goread.yml) with a small tweak ;)

```yml
keymap:
  browser:
    close_tab:
      - c
      - ctrl+w
    next_tab:
      - tab
    prev_tab:
      - shift+tab
    show_help:
      - h
      - ctrl+h
    toggle_offline_mode:
      - o
      - ctrl+o
  category:
    delete_feed:
      - d
      - ctrl+d
    edit_feed:
      - e
      - ctrl+e
    new_feed:
      - n
      - ctrl+n
  feed:
    cycle_selection:
      - g
    delete_from_saved:
      - d
    mark_as_unread:
      - u
    open:
      - enter
    open_in_pager:
      - p
      - ctrl+p
    refresh_articles:
      - r
      - ctrl+r
    save_article:
      - s
      - ctrl+s
    toggle_focus:
      - left
      - right
      - h
      - l
  list:
    down:
      - down
      - j
    open:
      - enter
    page_down:
      - shift+down
      - J
    page_up:
      - shift+up
      - K
    quick_select:
      - 0-9 # No effect
    up:
      - up
      - k
  overview:
    delete_category:
      - d
      - ctrl+d
    edit_category:
      - e
      - ctrl+e
    new_category:
      - n
      - ctrl+n
```